### PR TITLE
Update axis limits to use float values

### DIFF
--- a/Hello.py
+++ b/Hello.py
@@ -162,15 +162,15 @@ if uploaded_file is not None:
             first_numeric_col = numeric_cols[0]
             x_lim_min, x_lim_max = st.slider(
                 "X-axis Limits",
-                val_min,
-                int(data[first_numeric_col].max()),
-                (0, int(data[first_numeric_col].max())),
+                float(val_min),
+                float(data[first_numeric_col].max()),
+                (0.0, float(data[first_numeric_col].max())),
             )
             ymin, ymax = st.slider(
                 "Y-axis Limits",
-                int(data[numeric_cols].max().max()) * -2,
-                int(data[numeric_cols].max().max()) * 2,
-                (0, int(data[numeric_cols].max().max())),
+                float(data[numeric_cols].max().max()) * -2,
+                float(data[numeric_cols].max().max()) * 2,
+                (0.0, float(data[numeric_cols].max().max())),
             )
 
     # Trace settings section

--- a/plot_chromatogram.py
+++ b/plot_chromatogram.py
@@ -92,10 +92,10 @@ if uploaded_file is not None:
     title = st.text_input("Title of Plot", os.path.basename(uploaded_file.name))
     if len(numeric_cols) > 0:
         first_numeric_col = numeric_cols[0]
-        x_lim_min, x_lim_max = st.slider("X-axis Limits", 0, int(data[first_numeric_col].max()), (0, int(data[first_numeric_col].max())))    
+        x_lim_min, x_lim_max = st.slider("X-axis Limits", 0.0, float(data[first_numeric_col].max()), (0.0, float(data[first_numeric_col].max())))    
     
-    ymin = st.number_input("Y-axis Minimum", value=0)
-    ymax = st.number_input("Y-axis Maximum", value=int(data[numeric_cols].max().max()))
+    ymin = st.number_input("Y-axis Minimum", value=0.0)
+    ymax = st.number_input("Y-axis Maximum", value=float(data[numeric_cols].max().max()))
     figsize_width = st.slider("Figure Width", 5, 20, 10)
     figsize_height = st.slider("Figure Height", 3, 15, 5)
     figsize_dpi = st.selectbox("Figure DPI", [150,200,300,500])


### PR DESCRIPTION
Change the x and y axis limits sliders to use float values instead of integer values.

* **Hello.py**
  - Change the "X-axis Limits" slider to use float values instead of integer values.
  - Change the "Y-axis Limits" slider to use float values instead of integer values.

* **plot_chromatogram.py**
  - Change the "X-axis Limits" slider to use float values instead of integer values.
  - Change the "Y-axis Limits" slider to use float values instead of integer values.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dzyla/plot-chormatogram/pull/1?shareId=168decaa-48b3-49cf-938f-b412c65dbf25).