### PR TITLE
Add export format selection and update download functionality

### DIFF
--- a/Hello.py
+++ b/Hello.py
@@ -277,9 +277,10 @@ if uploaded_file is not None:
 
         # Download plot
         buf = io.BytesIO()
-        fig.savefig(buf, format="png")
+        export_format = st.selectbox("Select Export Format", ["png", "pdf", "svg"])
+        fig.savefig(buf, format=export_format)
         buf.seek(0)
         filename = os.path.basename(uploaded_file.name).replace(".csv", "")
-        st.download_button("Download Plot", buf, f"{filename}.png", "image/png")
+        st.download_button("Download Plot", buf, f"{filename}.{export_format}", f"image/{export_format}")
 
 st.write('Dawid Zyla 2024. Source code available on [GitHub](https://github.com/dzyla/plot-chormatogram/)')

--- a/plot_chromatogram.py
+++ b/plot_chromatogram.py
@@ -109,11 +109,12 @@ if uploaded_file is not None:
 
         # Download plot
         buf = io.BytesIO()
-        fig.savefig(buf, format="png")
+        export_format = st.selectbox("Select Export Format", ["png", "pdf", "svg"])
+        fig.savefig(buf, format=export_format)
         buf.seek(0)
         filename = uploaded_file.name
         filename = filename.replace('.csv','')
-        st.download_button("Download Plot", buf, f"{os.path.basename(filename)}.png", "image/png")
+        st.download_button("Download Plot", buf, f"{os.path.basename(filename)}.{export_format}", f"image/{export_format}")
 
 # Run the Streamlit app with 'streamlit run [filename].py'
 st.write('Dawid Zyla 2024. Source code available on [GitHub](https://github.com/dzyla/plot-chormatogram/)')


### PR DESCRIPTION
* Add a dropdown to select the export format (PNG, PDF, SVG)
* Modify `fig.savefig` to save the plot in the selected format
* Update `st.download_button` to download the plot in the selected format

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dzyla/plot-chormatogram?shareId=XXXX-XXXX-XXXX-XXXX).