### PR TITLE
Fix format selection for image export

### DIFF
--- a/Hello.py
+++ b/Hello.py
@@ -173,18 +173,6 @@ if uploaded_file is not None:
                 (0.0, float(data[numeric_cols].max().max())),
             )
 
-        # Check if export_format is in session_state, if not set it to "png"
-        if 'export_format' not in st.session_state:
-            st.session_state.export_format = "png"
-
-        # Export format selection
-        export_format = st.selectbox(
-            "Select Export Format",
-            ["png", "pdf", "svg"],
-            index=["png", "pdf", "svg"].index(st.session_state.export_format),
-            on_change=lambda: st.session_state.update(export_format=export_format)
-        )
-
     # Trace settings section
     # if n_traces > 1:
     #     num_traces = st.slider("Number of Traces", 1, n_traces, 1)
@@ -289,9 +277,18 @@ if uploaded_file is not None:
 
         # Download plot
         buf = io.BytesIO()
-        fig.savefig(buf, format=st.session_state.export_format)
-        buf.seek(0)
-        filename = os.path.basename(uploaded_file.name).replace(".csv", "")
-        st.download_button("Download Plot", buf, f"{filename}.{st.session_state.export_format}", f"image/{st.session_state.export_format}")
+        with st.form(key='export_form'):
+            export_format = st.selectbox(
+                "Select Export Format",
+                ["png", "pdf", "svg"],
+                index=["png", "pdf", "svg"].index(st.session_state.export_format),
+                on_change=lambda: st.session_state.update(export_format=export_format)
+            )
+            submit_button = st.form_submit_button(label='Download Plot')
+            if submit_button:
+                fig.savefig(buf, format=st.session_state.export_format)
+                buf.seek(0)
+                filename = os.path.basename(uploaded_file.name).replace(".csv", "")
+                st.download_button("Download Plot", buf, f"{filename}.{st.session_state.export_format}", f"image/{st.session_state.export_format}")
 
 st.write('Dawid Zyla 2024. Source code available on [GitHub](https://github.com/dzyla/plot-chormatogram/)')


### PR DESCRIPTION
Move the export format selection inside the `st.form` in `Hello.py`.

* Add the export format selection inside a new `st.form` with key 'export_form'.
* Add a form submit button labeled 'Download Plot' inside the `st.form`.
* Update the plot download logic to use the selected export format from the form.
* Ensure the plot is saved and downloaded in the selected format when the form is submitted.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dzyla/plot-chormatogram/pull/4?shareId=10940f41-1b88-47a0-8e20-7c3036757639).